### PR TITLE
Move player utility functions into players.py

### DIFF
--- a/commands/players.py
+++ b/commands/players.py
@@ -37,6 +37,28 @@ except Exception as e:
     print(f"Error loading max_lvl.json: {str(e)}")
     max_levels = {}
 
+async def get_linked_accounts(discord_id):
+    """Get linked accounts for a Discord user"""
+    if db is None:
+        print("Error: MongoDB not initialized for linked accounts")
+        return []
+    
+    try:
+        linked_players_collection = db.linked_players
+        result = await linked_players_collection.find_one({"discord_id": str(discord_id)})
+        if result:
+            # Combine verified and unverified accounts
+            verified = result.get("verified", [])
+            unverified = result.get("unverified", [])
+            all_accounts = verified + unverified
+            print(f"get_linked_accounts: Found {len(all_accounts)} accounts for user {discord_id}")
+            return all_accounts
+        print(f"get_linked_accounts: No linked accounts found for user {discord_id}")
+        return []
+    except Exception as e:
+        print(f"Error fetching linked accounts for user {discord_id}: {e}")
+        return []
+
 class PlayerEmbeds:
     ELIXIR_TROOPS = [
         "Barbarian", "Archer", "Giant", "Goblin", "Wall Breaker", "Balloon", "Wizard",
@@ -748,7 +770,6 @@ def setup(bot):
         
         # Handle user selection (show all their linked accounts)
         if user:
-            from commands.utils import get_linked_accounts
             user_accounts = await get_linked_accounts(user.id)
             
             if not user_accounts:


### PR DESCRIPTION
Move `get_linked_accounts` function from `utils.py` to `players.py` to remove external dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3cdd80b-063d-4c43-9c09-3c75cf321256">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f3cdd80b-063d-4c43-9c09-3c75cf321256">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>